### PR TITLE
Improve parsing logic to better align with what is supported by pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.1
 
 - Fixed name collision with error type in latest `package:json_annotation`.
-- Improved parsing of hosted dependencies.
+- Improved parsing of hosted dependencies and environment constraints.
 
 ## 0.1.0
 

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -62,12 +62,7 @@ Dependency _fromJson(dynamic data) {
 }
 
 Dependency _fromMap(Map data) {
-  if (data.entries.isEmpty) {
-// TODO: provide list of supported keys?
-    throw new CheckedFromJsonException(
-        data, null, 'Dependency', 'Must provide at least one key.');
-  }
-
+  assert(data.entries.isNotEmpty);
   if (data.entries.length > 1) {
     throw new CheckedFromJsonException(data, data.keys.skip(1).first as String,
         'Dependency', 'Expected only one key.');
@@ -179,9 +174,12 @@ class HostedDependency extends Dependency {
       data = {'version': data};
     }
 
-    if (data is Map &&
-        (data.containsKey('version') || data.containsKey('hosted'))) {
-      return _$HostedDependencyFromJson(data);
+    if (data is Map) {
+      if (data.isEmpty ||
+          data.containsKey('version') ||
+          data.containsKey('hosted')) {
+        return _$HostedDependencyFromJson(data);
+      }
     }
 
     return null;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -124,8 +124,10 @@ Map<String, VersionConstraint> _environmentMap(Map source) =>
             source, 'dart', 'Use "sdk" to for Dart SDK constraints.');
       }
 
-      if (value is String) {
-        VersionConstraint constraint;
+      VersionConstraint constraint;
+      if (value == null) {
+        constraint = null;
+      } else if (value is String) {
         try {
           constraint = new VersionConstraint.parse(value);
         } on FormatException catch (e) {
@@ -133,8 +135,10 @@ Map<String, VersionConstraint> _environmentMap(Map source) =>
         }
 
         return new MapEntry(key, constraint);
+      } else {
+        throw new CheckedFromJsonException(
+            source, key, 'VersionConstraint', '`$value` is not a String.');
       }
 
-      throw new CheckedFromJsonException(
-          source, key, 'VersionConstraint', '`$value` is not a String.');
+      return new MapEntry(key, constraint);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,3 +20,5 @@ dev_dependencies:
   path: ^1.5.1
   stack_trace: ^1.9.2
   test: ^0.12.0
+  test_descriptor: ^1.0.3
+  test_process: ^1.0.2

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -29,13 +29,6 @@ line 4, column 10: Not a valid dependency value.
          ^^^''');
     });
 
-    test('empty map', () {
-      _expectThrows({}, r'''
-line 4, column 10: Must provide at least one key.
-  "dep": {}
-         ^^''');
-    });
-
     test('map with too many keys', () {
       _expectThrows({'path': 'a', 'git': 'b'}, r'''
 line 5, column 12: Expected only one key.
@@ -49,6 +42,12 @@ void _hostedDependency() {
   test('null', () {
     var dep = _dependency<HostedDependency>(null);
     expect(dep.version.toString(), 'any');
+    expect(dep.hosted, isNull);
+    expect(dep.toString(), 'HostedDependency: any');
+  });
+
+  test('empty map', () {
+    var dep = _dependency<HostedDependency>({});
     expect(dep.hosted, isNull);
     expect(dep.toString(), 'HostedDependency: any');
   });

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -25,29 +25,40 @@ void main() {
   });
 
   test('all fields set', () {
-    var constraint = new Version.parse('1.2.3');
+    var version = new Version.parse('1.2.3');
+    var sdkConstraint = new VersionConstraint.parse('>=2.0.0-dev.54 <2.0.0');
     var value = parse({
       'name': 'sample',
-      'version': constraint.toString(),
+      'version': version.toString(),
       'author': 'name@example.com',
-      'environment': {'sdk': '1.2.3'},
+      'environment': {'sdk': sdkConstraint.toString()},
       'description': 'description',
       'homepage': 'homepage',
       'documentation': 'documentation'
     });
     expect(value.name, 'sample');
-    expect(value.version, constraint);
+    expect(value.version, version);
     expect(value.description, 'description');
     expect(value.homepage, 'homepage');
     // ignore: deprecated_member_use
     expect(value.author, 'name@example.com');
     expect(value.authors, ['name@example.com']);
     expect(value.environment, hasLength(1));
-    expect(value.environment, containsPair('sdk', constraint));
+    expect(value.environment, containsPair('sdk', sdkConstraint));
     expect(value.documentation, 'documentation');
     expect(value.dependencies, isEmpty);
     expect(value.devDependencies, isEmpty);
     expect(value.dependencyOverrides, isEmpty);
+  });
+
+  test('environment values can be null', () {
+    var value = parse({
+      'name': 'sample',
+      'environment': {'sdk': null}
+    });
+    expect(value.name, 'sample');
+    expect(value.environment, hasLength(1));
+    expect(value.environment, containsPair('sdk', isNull));
   });
 
   group('author, authors', () {
@@ -130,16 +141,6 @@ line 1, column 1: "name" cannot be empty.
 line 4, column 3: Use "sdk" to for Dart SDK constraints.
   "dart": "cool"
   ^^^^^^''');
-    });
-
-    test('environment values cannot be null', () {
-      expectParseThrows({
-        'name': 'sample',
-        'environment': {'sdk': null}
-      }, r'''
-line 4, column 10: `null` is not a String.
-  "sdk": null
-         ^^^^^''');
     });
 
     test('environment values cannot be int', () {

--- a/test/pub_utils.dart
+++ b/test/pub_utils.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:test_process/test_process.dart';
+
+Future<ProcResult> tryPub(String content) async {
+  await d.file('pubspec.yaml', content).create();
+
+  var proc = await TestProcess.start(_pubPath, ['get', '--offline'],
+      workingDirectory: d.sandbox);
+
+  var result = await ProcResult.fromTestProcess(proc);
+
+  printOnFailure([
+    '-----BEGIN pub output-----',
+    result.toString().trim(),
+    '-----END pub output-----',
+  ].join('\n'));
+
+  if (result.exitCode == 0) {
+    var lockContent =
+        new File(p.join(d.sandbox, 'pubspec.lock')).readAsStringSync();
+
+    printOnFailure([
+      '-----BEGIN pubspec.lock-----',
+      lockContent.trim(),
+      '-----END pubspec.lock-----',
+    ].join('\n'));
+  }
+
+  return result;
+}
+
+class ProcResult {
+  final int exitCode;
+  final List<ProcLine> lines;
+
+  bool get cleanParse => exitCode == 0 || exitCode == 66 || exitCode == 69;
+
+  ProcResult(this.exitCode, this.lines);
+
+  static Future<ProcResult> fromTestProcess(TestProcess proc) async {
+    var items = <ProcLine>[];
+
+    var values = await Future.wait([
+      proc.exitCode,
+      proc
+          .stdoutStream()
+          .forEach((line) => items.add(new ProcLine(false, line))),
+      proc
+          .stderrStream()
+          .forEach((line) => items.add(new ProcLine(true, line))),
+    ]);
+
+    return new ProcResult(values[0] as int, items);
+  }
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer('Exit code: $exitCode');
+    for (var line in lines) {
+      buffer.write('\n$line');
+    }
+    return buffer.toString();
+  }
+}
+
+class ProcLine {
+  final bool isError;
+  final String line;
+
+  ProcLine(this.isError, this.line);
+
+  @override
+  String toString() => '${isError ? 'err' : 'out'}  $line';
+}
+
+/// The path to the root directory of the SDK.
+final String _sdkDir = (() {
+  // The Dart executable is in "/path/to/sdk/bin/dart", so two levels up is
+  // "/path/to/sdk".
+  var aboveExecutable = p.dirname(p.dirname(Platform.resolvedExecutable));
+  assert(FileSystemEntity.isFileSync(p.join(aboveExecutable, 'version')));
+  return aboveExecutable;
+})();
+
+final String _pubPath =
+    p.join(_sdkDir, 'bin', Platform.isWindows ? 'pub.bat' : 'pub');


### PR DESCRIPTION
* Allow environment constraint values to be null
* Treat dependencies with empty map values like they are empty.

* Use an SDK constraint in tests that is compatible with the supported
  SDK

* Update tests to verify behavior of pub client
  * Failing test cases should cause the pub client to report a parse error
  * Successful test cases should be parsed successfully by the pub client,
    even if pub get ends up failing for another reason