### PR TITLE
Parsing option: lenient.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+- Parsing option: `lenient` to ignore format and type errors. 
+
 ## 0.1.3
 
 - Added support for `flutter`, `issue_tracker`, `publish_to`, and `repository`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.4
 
-- Parsing option: `lenient` to ignore format and type errors. 
+- Added `lenient` named argument to `Pubspec.fromJson` to ignore format and type errors. 
 
 ## 0.1.3
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -121,6 +121,7 @@ class Pubspec {
 
     if (lenient) {
       for (;;) {
+        // Attempting to remove top-level properties that cause parsing errors.
         try {
           return _$PubspecFromJson(json);
         } on CheckedFromJsonException catch (e) {

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -120,7 +120,7 @@ class Pubspec {
     lenient ??= false;
 
     if (lenient) {
-      for (;;) {
+      while (json.isNotEmpty) {
         // Attempting to remove top-level properties that cause parsing errors.
         try {
           return _$PubspecFromJson(json);

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -132,9 +132,9 @@ class Pubspec {
           rethrow;
         }
       }
-    } else {
-      return _$PubspecFromJson(json);
     }
+
+    return _$PubspecFromJson(json);
   }
 
   factory Pubspec.parse(String yaml, {sourceUrl, bool lenient = false}) {

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -138,6 +138,10 @@ class Pubspec {
     return _$PubspecFromJson(json);
   }
 
+  /// Parses source [yaml] into [Pubspec].
+  ///
+  /// When [lenient] is set, top-level property-parsing or type cast errors are
+  /// ignored and `null` values are returned.
   factory Pubspec.parse(String yaml, {sourceUrl, bool lenient = false}) {
     lenient ??= false;
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -116,9 +116,30 @@ class Pubspec {
     }
   }
 
-  factory Pubspec.fromJson(Map json) => _$PubspecFromJson(json);
+  factory Pubspec.fromJson(Map json, {bool lenient = false}) {
+    lenient ??= false;
 
-  factory Pubspec.parse(String yaml, {sourceUrl}) {
+    if (lenient) {
+      for (;;) {
+        try {
+          return _$PubspecFromJson(json);
+        } on CheckedFromJsonException catch (e) {
+          if (e.map == json && json.containsKey(e.key)) {
+            json = Map.from(json);
+            json.remove(e.key);
+            continue;
+          }
+          rethrow;
+        }
+      }
+    } else {
+      return _$PubspecFromJson(json);
+    }
+  }
+
+  factory Pubspec.parse(String yaml, {sourceUrl, bool lenient = false}) {
+    lenient ??= false;
+
     final item = loadYaml(yaml, sourceUrl: sourceUrl);
 
     if (item == null) {
@@ -134,7 +155,7 @@ class Pubspec {
     }
 
     try {
-      return Pubspec.fromJson(item as YamlMap);
+      return Pubspec.fromJson(item as YamlMap, lenient: lenient);
     } on CheckedFromJsonException catch (error, stack) {
       throw parsedYamlExceptionFromError(error, stack);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: pubspec_parse
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/dart-lang/pubspec_parse
 author: Dart Team <misc@dartlang.org>
 

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -294,5 +294,19 @@ line 3, column 19: Unsupported value for `issue_tracker`.
       expect(value.repository, isNull);
       expect(value.issueTracker, isNull);
     });
+
+    test('deep error throws with lenient', () {
+      expect(
+          () => parse({
+                'name': 'foo',
+                'dependencies': {
+                  'foo': {
+                    'git': {'url': 1}
+                  },
+                },
+                'issue_tracker': {'x': 'y'},
+              }, skipTryPub: true, lenient: true),
+          throwsException);
+    });
   });
 }

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -222,5 +222,77 @@ line 4, column 10: Could not parse version "silly". Unknown text at "silly".
   "sdk": "silly"
          ^^^^^^^''');
     });
+
+    test('bad repository url', () {
+      expectParseThrows({
+        'name': 'foo',
+        'repository': {'x': 'y'},
+      }, r'''
+line 3, column 16: Unsupported value for `repository`.
+ "repository": {
+               ^^''', skipTryPub: true);
+    });
+
+    test('bad issue_tracker url', () {
+      expectParseThrows({
+        'name': 'foo',
+        'issue_tracker': {'x': 'y'},
+      }, r'''
+line 3, column 19: Unsupported value for `issue_tracker`.
+ "issue_tracker": {
+                  ^^''', skipTryPub: true);
+    });
+  });
+
+  group('lenient', () {
+    test('null', () {
+      expect(() => parse(null, lenient: true), throwsArgumentError);
+    });
+
+    test('empty string', () {
+      expect(() => parse('', lenient: true), throwsArgumentError);
+    });
+
+    test('name cannot be empty', () {
+      expect(() => parse({}, lenient: true), throwsException);
+    });
+
+    test('bad repository url', () {
+      final value = parse(
+        {
+          'name': 'foo',
+          'repository': {'x': 'y'},
+        },
+        lenient: true,
+      );
+      expect(value.name, 'foo');
+      expect(value.repository, isNull);
+    });
+
+    test('bad issue_tracker url', () {
+      final value = parse(
+        {
+          'name': 'foo',
+          'issue_tracker': {'x': 'y'},
+        },
+        lenient: true,
+      );
+      expect(value.name, 'foo');
+      expect(value.issueTracker, isNull);
+    });
+
+    test('multiple bad values', () {
+      final value = parse(
+        {
+          'name': 'foo',
+          'repository': {'x': 'y'},
+          'issue_tracker': {'x': 'y'},
+        },
+        lenient: true,
+      );
+      expect(value.name, 'foo');
+      expect(value.repository, isNull);
+      expect(value.issueTracker, isNull);
+    });
   });
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -48,10 +48,15 @@ void _printDebugParsedYamlException(ParsedYamlException e) {
   }
 }
 
-Pubspec parse(Object content,
-    {bool quietOnError = false, bool skipTryPub = false}) {
+Pubspec parse(
+  Object content, {
+  bool quietOnError = false,
+  bool skipTryPub = false,
+  bool lenient = false,
+}) {
   quietOnError ??= false;
   skipTryPub ??= false;
+  lenient ??= false;
 
   final encoded = _encodeJson(content);
 
@@ -62,7 +67,7 @@ Pubspec parse(Object content,
   }
 
   try {
-    final value = Pubspec.parse(encoded);
+    final value = Pubspec.parse(encoded, lenient: lenient);
 
     if (pubResult != null) {
       addTearDown(() {


### PR DESCRIPTION
A bit of alternative to @jonasfj's [per-property parsing](https://github.com/dart-lang/pubspec_parse/issues/35#issuecomment-451388191): instead of parsing it on per-property, we remove the top-level key on each reporter error.

This does not yet delegate the lenient flag to embedded classes like `Dependency` (and I'm not sure if it is feasible to without either `json_serializable` support or using zones).