### PR TITLE
Bump min Dart SDK to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.6.0
+  - 2.7.0
   - dev
 
 dart_task:
@@ -16,7 +16,7 @@ matrix:
     - dart: dev
       dart_task:
         dartanalyzer: --fatal-infos --fatal-warnings .
-    - dart: 2.6.0
+    - dart: 2.7.0
       dart_task:
         dartanalyzer: --fatal-warnings .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.6-dev
 
-- Update SDK requirement to `>=2.6.0 <3.0.0`.
+- Update SDK requirement to `>=2.7.0 <3.0.0`.
 
 ## 0.1.5
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.1.6-dev
 homepage: https://github.com/dart-lang/pubspec_parse
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   checked_yaml: ^1.0.0


### PR DESCRIPTION
Works-around issue with testing Dart 2.6 in CI and changes to pkg:analyzer

Specifically, it seems there was a change to a non-public analyzer API that is picked up by packages on Dart 2.6 but the SDK constraint on `dart_style` prevents picking up a version of that package with the fix.