### PR TITLE
Fix tests for latest pub parsing rules for environment

### DIFF
--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -404,8 +404,7 @@ void _expectThrows(Object content, String expectedError) {
 
 T _dependency<T extends Dependency>(Object content, {bool skipTryPub = false}) {
   final value = parse({
-    'name': 'sample',
-    ...defaultEnvironment,
+    ...defaultPubspec,
     'dependencies': {'dep': content}
   }, skipTryPub: skipTryPub);
   expect(value.name, 'sample');

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -214,7 +214,7 @@ line 5, column 4: These keys had `null` values, which is not allowed: [sdk]
     _expectThrows(
       {'sdk': 42},
       r'''
-line 5, column 11: Unsupported value for "sdk".
+line 5, column 11: Unsupported value for "sdk". type 'int' is not a subtype of type 'String' in type cast
   ╷
 5 │      "sdk": 42
   │ ┌───────────^
@@ -332,7 +332,7 @@ line 6, column 5: These keys had `null` values, which is not allowed: [url]
         'git': {'url': 42}
       },
       r'''
-line 6, column 12: Unsupported value for "url".
+line 6, column 12: Unsupported value for "url". type 'int' is not a subtype of type 'String' in type cast
   ╷
 6 │       "url": 42
   │ ┌────────────^

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -405,6 +405,7 @@ void _expectThrows(Object content, String expectedError) {
 T _dependency<T extends Dependency>(Object content, {bool skipTryPub = false}) {
   final value = parse({
     'name': 'sample',
+    ...defaultEnvironment,
     'dependencies': {'dep': content}
   }, skipTryPub: skipTryPub);
   expect(value.name, 'sample');

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -86,7 +86,7 @@ void main() {
   group('publish_to', () {
     for (var entry in {
       42: r'''
-line 3, column 16: Unsupported value for "publish_to".
+line 3, column 16: Unsupported value for "publish_to". type 'int' is not a subtype of type 'String' in type cast
   ╷
 3 │  "publish_to": 42
   │                ^^
@@ -298,7 +298,7 @@ line 4, column 10: Unsupported value for "sdk". Could not parse version "silly".
           'repository': {'x': 'y'},
         },
         r'''
-line 6, column 16: Unsupported value for "repository".
+line 6, column 16: Unsupported value for "repository". type 'YamlMap' is not a subtype of type 'String' in type cast
   ╷
 6 │    "repository": {
   │ ┌────────────────^
@@ -316,7 +316,7 @@ line 6, column 16: Unsupported value for "repository".
           'issue_tracker': {'x': 'y'},
         },
         r'''
-line 3, column 19: Unsupported value for "issue_tracker".
+line 3, column 19: Unsupported value for "issue_tracker". type 'YamlMap' is not a subtype of type 'String' in type cast
   ╷
 3 │    "issue_tracker": {
   │ ┌───────────────────^

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -25,7 +25,7 @@ void main() {
     expect(value.authors, isEmpty);
     expect(
       value.environment,
-      {'sdk': VersionConstraint.parse('>=2.10.0 <3.0.0')},
+      {'sdk': VersionConstraint.parse('>=2.7.0 <3.0.0')},
     );
     expect(value.documentation, isNull);
     expect(value.dependencies, isEmpty);
@@ -74,7 +74,7 @@ void main() {
     final value = parse({
       'name': 'sample',
       'environment': {
-        'sdk': '>=2.10.0 <3.0.0',
+        'sdk': '>=2.7.0 <3.0.0',
         'bob': null,
       }
     });

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -14,10 +14,7 @@ import 'test_utils.dart';
 
 void main() {
   test('minimal set values', () {
-    final value = parse({
-      'name': 'sample',
-      ...defaultEnvironment,
-    });
+    final value = parse(defaultPubspec);
     expect(value.name, 'sample');
     expect(value.version, isNull);
     expect(value.publishTo, isNull);
@@ -130,8 +127,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
     }.entries) {
       test('can be ${entry.key}', () {
         final value = parse({
-          'name': 'sample',
-          ...defaultEnvironment,
+          ...defaultPubspec,
           'publish_to': entry.value,
         });
         expect(value.publishTo, entry.value);
@@ -142,8 +138,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
   group('author, authors', () {
     test('one author', () {
       final value = parse({
-        'name': 'sample',
-        ...defaultEnvironment,
+        ...defaultPubspec,
         'author': 'name@example.com',
       });
       // ignore: deprecated_member_use_from_same_package
@@ -153,8 +148,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
 
     test('one author, via authors', () {
       final value = parse({
-        'name': 'sample',
-        ...defaultEnvironment,
+        ...defaultPubspec,
         'authors': ['name@example.com']
       });
       // ignore: deprecated_member_use_from_same_package
@@ -164,8 +158,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
 
     test('many authors', () {
       final value = parse({
-        'name': 'sample',
-        ...defaultEnvironment,
+        ...defaultPubspec,
         'authors': ['name@example.com', 'name2@example.com']
       });
       // ignore: deprecated_member_use_from_same_package
@@ -175,8 +168,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
 
     test('author and authors', () {
       final value = parse({
-        'name': 'sample',
-        ...defaultEnvironment,
+        ...defaultPubspec,
         'author': 'name@example.com',
         'authors': ['name2@example.com']
       });
@@ -187,8 +179,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
 
     test('duplicate author values', () {
       final value = parse({
-        'name': 'sample',
-        ...defaultEnvironment,
+        ...defaultPubspec,
         'author': 'name@example.com',
         'authors': ['name@example.com', 'name@example.com']
       });
@@ -199,8 +190,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
 
     test('flutter', () {
       final value = parse({
-        'name': 'sample',
-        ...defaultEnvironment,
+        ...defaultPubspec,
         'flutter': {'key': 'value'},
       });
       expect(value.flutter, {'key': 'value'});
@@ -304,8 +294,7 @@ line 4, column 10: Unsupported value for "sdk". Could not parse version "silly".
     test('bad repository url', () {
       expectParseThrows(
         {
-          'name': 'foo',
-          ...defaultEnvironment,
+          ...defaultPubspec,
           'repository': {'x': 'y'},
         },
         r'''
@@ -323,7 +312,7 @@ line 6, column 16: Unsupported value for "repository".
     test('bad issue_tracker url', () {
       expectParseThrows(
         {
-          'name': 'foo',
+          'name': 'sample',
           'issue_tracker': {'x': 'y'},
         },
         r'''
@@ -382,40 +371,37 @@ line 1, column 1: "name" cannot be empty.
     test('bad repository url', () {
       final value = parse(
         {
-          'name': 'foo',
-          ...defaultEnvironment,
+          ...defaultPubspec,
           'repository': {'x': 'y'},
         },
         lenient: true,
       );
-      expect(value.name, 'foo');
+      expect(value.name, 'sample');
       expect(value.repository, isNull);
     });
 
     test('bad issue_tracker url', () {
       final value = parse(
         {
-          'name': 'foo',
-          ...defaultEnvironment,
+          ...defaultPubspec,
           'issue_tracker': {'x': 'y'},
         },
         lenient: true,
       );
-      expect(value.name, 'foo');
+      expect(value.name, 'sample');
       expect(value.issueTracker, isNull);
     });
 
     test('multiple bad values', () {
       final value = parse(
         {
-          'name': 'foo',
-          ...defaultEnvironment,
+          ...defaultPubspec,
           'repository': {'x': 'y'},
           'issue_tracker': {'x': 'y'},
         },
         lenient: true,
       );
-      expect(value.name, 'foo');
+      expect(value.name, 'sample');
       expect(value.repository, isNull);
       expect(value.issueTracker, isNull);
     });
@@ -423,7 +409,7 @@ line 1, column 1: "name" cannot be empty.
     test('deep error throws with lenient', () {
       expect(
           () => parse({
-                'name': 'foo',
+                'name': 'sample',
                 'dependencies': {
                   'foo': {
                     'git': {'url': 1}

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -14,7 +14,10 @@ import 'test_utils.dart';
 
 void main() {
   test('minimal set values', () {
-    final value = parse({'name': 'sample'});
+    final value = parse({
+      'name': 'sample',
+      ...defaultEnvironment,
+    });
     expect(value.name, 'sample');
     expect(value.version, isNull);
     expect(value.publishTo, isNull);
@@ -23,7 +26,10 @@ void main() {
     // ignore: deprecated_member_use_from_same_package
     expect(value.author, isNull);
     expect(value.authors, isEmpty);
-    expect(value.environment, isEmpty);
+    expect(
+      value.environment,
+      {'sdk': VersionConstraint.parse('>=2.10.0 <3.0.0')},
+    );
     expect(value.documentation, isNull);
     expect(value.dependencies, isEmpty);
     expect(value.devDependencies, isEmpty);
@@ -70,11 +76,14 @@ void main() {
   test('environment values can be null', () {
     final value = parse({
       'name': 'sample',
-      'environment': {'sdk': null}
+      'environment': {
+        'sdk': '>=2.10.0 <3.0.0',
+        'bob': null,
+      }
     });
     expect(value.name, 'sample');
-    expect(value.environment, hasLength(1));
-    expect(value.environment, containsPair('sdk', isNull));
+    expect(value.environment, hasLength(2));
+    expect(value.environment, containsPair('bob', isNull));
   });
 
   group('publish_to', () {
@@ -120,7 +129,11 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
       'none': 'none'
     }.entries) {
       test('can be ${entry.key}', () {
-        final value = parse({'name': 'sample', 'publish_to': entry.value});
+        final value = parse({
+          'name': 'sample',
+          ...defaultEnvironment,
+          'publish_to': entry.value,
+        });
         expect(value.publishTo, entry.value);
       });
     }
@@ -128,7 +141,11 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
 
   group('author, authors', () {
     test('one author', () {
-      final value = parse({'name': 'sample', 'author': 'name@example.com'});
+      final value = parse({
+        'name': 'sample',
+        ...defaultEnvironment,
+        'author': 'name@example.com',
+      });
       // ignore: deprecated_member_use_from_same_package
       expect(value.author, 'name@example.com');
       expect(value.authors, ['name@example.com']);
@@ -137,6 +154,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
     test('one author, via authors', () {
       final value = parse({
         'name': 'sample',
+        ...defaultEnvironment,
         'authors': ['name@example.com']
       });
       // ignore: deprecated_member_use_from_same_package
@@ -147,6 +165,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
     test('many authors', () {
       final value = parse({
         'name': 'sample',
+        ...defaultEnvironment,
         'authors': ['name@example.com', 'name2@example.com']
       });
       // ignore: deprecated_member_use_from_same_package
@@ -157,6 +176,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
     test('author and authors', () {
       final value = parse({
         'name': 'sample',
+        ...defaultEnvironment,
         'author': 'name@example.com',
         'authors': ['name2@example.com']
       });
@@ -168,6 +188,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
     test('duplicate author values', () {
       final value = parse({
         'name': 'sample',
+        ...defaultEnvironment,
         'author': 'name@example.com',
         'authors': ['name@example.com', 'name@example.com']
       });
@@ -179,6 +200,7 @@ line 3, column 16: Unsupported value for "publish_to". Must be an http or https 
     test('flutter', () {
       final value = parse({
         'name': 'sample',
+        ...defaultEnvironment,
         'flutter': {'key': 'value'},
       });
       expect(value.flutter, {'key': 'value'});
@@ -283,15 +305,16 @@ line 4, column 10: Unsupported value for "sdk". Could not parse version "silly".
       expectParseThrows(
         {
           'name': 'foo',
+          ...defaultEnvironment,
           'repository': {'x': 'y'},
         },
         r'''
-line 3, column 16: Unsupported value for "repository".
+line 6, column 16: Unsupported value for "repository".
   ╷
-3 │    "repository": {
+6 │    "repository": {
   │ ┌────────────────^
-4 │ │   "x": "y"
-5 │ └  }
+7 │ │   "x": "y"
+8 │ └  }
   ╵''',
         skipTryPub: true,
       );
@@ -360,6 +383,7 @@ line 1, column 1: "name" cannot be empty.
       final value = parse(
         {
           'name': 'foo',
+          ...defaultEnvironment,
           'repository': {'x': 'y'},
         },
         lenient: true,
@@ -372,6 +396,7 @@ line 1, column 1: "name" cannot be empty.
       final value = parse(
         {
           'name': 'foo',
+          ...defaultEnvironment,
           'issue_tracker': {'x': 'y'},
         },
         lenient: true,
@@ -384,6 +409,7 @@ line 1, column 1: "name" cannot be empty.
       final value = parse(
         {
           'name': 'foo',
+          ...defaultEnvironment,
           'repository': {'x': 'y'},
           'issue_tracker': {'x': 'y'},
         },

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -13,7 +13,8 @@ import 'package:test/test.dart';
 
 import 'pub_utils.dart';
 
-const defaultEnvironment = {
+const defaultPubspec = {
+  'name': 'sample',
   'environment': {'sdk': '>=2.10.0 <3.0.0'},
 };
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -15,7 +15,7 @@ import 'pub_utils.dart';
 
 const defaultPubspec = {
   'name': 'sample',
-  'environment': {'sdk': '>=2.10.0 <3.0.0'},
+  'environment': {'sdk': '>=2.7.0 <3.0.0'},
 };
 
 String _encodeJson(Object input) =>

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -13,6 +13,10 @@ import 'package:test/test.dart';
 
 import 'pub_utils.dart';
 
+const defaultEnvironment = {
+  'environment': {'sdk': '>=2.10.0 <3.0.0'},
+};
+
 String _encodeJson(Object input) =>
     const JsonEncoder.withIndent(' ').convert(input);
 


### PR DESCRIPTION
Since https://github.com/dart-lang/pub/commit/656803e924eae5cf6574f5200232ef69ac3b4f92  (SDK-2.12.0-28.0.dev) pub requires an 
SDK constraint.

Update tests so this requirement no longer causes failures.