### PR TITLE
Export the `HostedDetails` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.1-dev
 
+- Export `HostedDetails` publicly.
+
 ## 1.0.0
 
 - Migrate to null-safety.
@@ -26,7 +28,7 @@
 
 ## 0.1.4
 
-- Added `lenient` named argument to `Pubspec.fromJson` to ignore format and type errors. 
+- Added `lenient` named argument to `Pubspec.fromJson` to ignore format and type errors.
 
 ## 0.1.3
 

--- a/lib/pubspec_parse.dart
+++ b/lib/pubspec_parse.dart
@@ -6,6 +6,7 @@ export 'src/dependency.dart'
     show
         Dependency,
         HostedDependency,
+        HostedDetails,
         GitDependency,
         SdkDependency,
         PathDependency;


### PR DESCRIPTION
[The public `HostedDependency` class has a `details` field of type `HostedDetails`](https://github.com/dart-lang/pubspec_parse/blob/master/lib/src/dependency.dart#L191), but this type is not public.

This makes it impossible (without importing from `src/`) to:
- construct a `HostedDependency` instance with a non-null details field
- write a test stub/mock of the `HostedDependency` class

FYA @kevmoo 