### PR TITLE
Match hosted shorthand syntax from Dart 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 2.0.0-dev
+## 1.2.0-dev
 
-- __Breaking__: `HostedDetails.name` is now nullable to reflect changes from
-  Dart 2.15. Use the name from the package instead.
+- Update `HostedDetails` to reflect how `hosted` dependencies are parsed in
+  Dart 2.15:
+   - Add `HostedDetails.declaredName` as the (optional) `name` property in a 
+     `hosted` block.
+   - `HostedDetails.name` now falls back to the name of the dependency if no
+      name is declared in the block.
 
 ## 1.1.1-dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-dev
+
+- __Breaking__: `HostedDetails.name` is now nullable to reflect changes from
+  Dart 2.15. Use the name from the package instead.
+
 ## 1.1.1-dev
 
 - Require Dart SDK >= 2.14.0

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -211,7 +211,7 @@ class HostedDependency extends Dependency {
 
 @JsonSerializable(disallowUnrecognizedKeys: true)
 class HostedDetails {
-  final String name;
+  final String? name;
 
   @JsonKey(fromJson: parseGitUriOrNull, disallowNullValue: true)
   final Uri? url;
@@ -220,7 +220,7 @@ class HostedDetails {
 
   factory HostedDetails.fromJson(Object data) {
     if (data is String) {
-      data = {'name': data};
+      data = {'url': data};
     }
 
     if (data is Map) {

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -14,7 +14,7 @@ Map<String, Dependency> parseDeps(Map? source) =>
       final key = k as String;
       Dependency? value;
       try {
-        value = _fromJson(v);
+        value = _fromJson(v, k);
       } on CheckedFromJsonException catch (e) {
         if (e.map is! YamlMap) {
           // This is likely a "synthetic" map created from a String value
@@ -40,7 +40,7 @@ Map<String, Dependency> parseDeps(Map? source) =>
 const _sourceKeys = ['sdk', 'git', 'path', 'hosted'];
 
 /// Returns `null` if the data could not be parsed.
-Dependency? _fromJson(Object? data) {
+Dependency? _fromJson(Object? data, String name) {
   if (data is String || data == null) {
     return _$HostedDependencyFromJson({'version': data});
   }
@@ -82,7 +82,9 @@ Dependency? _fromJson(Object? data) {
           case 'sdk':
             return _$SdkDependencyFromJson(data);
           case 'hosted':
-            return _$HostedDependencyFromJson(data);
+            final hosted = _$HostedDependencyFromJson(data);
+            hosted.hosted?._nameOfPackage = name;
+            return hosted;
         }
         throw StateError('There is a bug in pubspec_parse.');
       });
@@ -211,12 +213,26 @@ class HostedDependency extends Dependency {
 
 @JsonSerializable(disallowUnrecognizedKeys: true)
 class HostedDetails {
-  final String? name;
+  /// The name of the target dependency as declared in a `hosted` block.
+  ///
+  /// This may be null if no explicit name is present, for instance because the
+  /// hosted dependency was declared as a string (`hosted: pub.example.org`).
+  @JsonKey(name: 'name')
+  final String? declaredName;
 
   @JsonKey(fromJson: parseGitUriOrNull, disallowNullValue: true)
   final Uri? url;
 
-  HostedDetails(this.name, this.url);
+  @JsonKey(ignore: true)
+  String? _nameOfPackage;
+
+  /// The name of this package on the package repository.
+  ///
+  /// If this hosted block has a [declaredName], that one will be used.
+  /// Otherwise, the name will be inferred from the surrounding package name.
+  String get name => declaredName ?? _nameOfPackage!;
+
+  HostedDetails(this.declaredName, this.url);
 
   factory HostedDetails.fromJson(Object data) {
     if (data is String) {

--- a/lib/src/dependency.g.dart
+++ b/lib/src/dependency.g.dart
@@ -68,4 +68,5 @@ HostedDetails _$HostedDetailsFromJson(Map json) => $checkedCreate(
         );
         return val;
       },
+      fieldKeyMap: const {'declaredName': 'name'},
     );

--- a/lib/src/dependency.g.dart
+++ b/lib/src/dependency.g.dart
@@ -63,7 +63,7 @@ HostedDetails _$HostedDetailsFromJson(Map json) => $checkedCreate(
           disallowNullValues: const ['url'],
         );
         final val = HostedDetails(
-          $checkedConvert('name', (v) => v as String),
+          $checkedConvert('name', (v) => v as String?),
           $checkedConvert('url', (v) => parseGitUriOrNull(v as String?)),
         );
         return val;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: pubspec_parse
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.
-version: 2.0.0-dev
+version: 1.2.0-dev
 repository: https://github.com/dart-lang/pubspec_parse
 
 environment:
@@ -27,11 +27,3 @@ dev_dependencies:
   test: ^1.0.0
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
-
-# These are (transitive) dev-dependencies depending on 1.x of this package.
-# The overrides can be removed for publishing and after the build system
-# supports version 2.x of pubspec_parse.
-dependency_overrides: 
-  build_config: ^1.0.0
-  build_runner: ^2.1.2
-  json_serializable: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: pubspec_parse
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.
-version: 1.1.1-dev
+version: 2.0.0-dev
 repository: https://github.com/dart-lang/pubspec_parse
 
 environment:
@@ -27,3 +27,11 @@ dev_dependencies:
   test: ^1.0.0
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
+
+# These are (transitive) dev-dependencies depending on 1.x of this package.
+# The overrides can be removed for publishing and after the build system
+# supports version 2.x of pubspec_parse.
+dependency_overrides: 
+  build_config: ^1.0.0
+  build_runner: ^2.1.2
+  json_serializable: ^6.0.0

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -153,19 +153,19 @@ line 10, column 4: Unrecognized keys: [not_supported]; supported keys: [sdk, git
 
   test('map w/ version and hosted as String', () {
     final dep = _dependency<HostedDependency>(
-      {'version': '^1.0.0', 'hosted': 'hosted_name'},
+      {'version': '^1.0.0', 'hosted': 'hosted_url'},
     );
     expect(dep.version.toString(), '^1.0.0');
-    expect(dep.hosted!.name, 'hosted_name');
-    expect(dep.hosted!.url, isNull);
+    expect(dep.hosted!.name, isNull);
+    expect(dep.hosted!.url, Uri.parse('hosted_url'));
     expect(dep.toString(), 'HostedDependency: ^1.0.0');
   });
 
   test('map w/ hosted as String', () {
-    final dep = _dependency<HostedDependency>({'hosted': 'hosted_name'});
+    final dep = _dependency<HostedDependency>({'hosted': 'hosted_url'});
     expect(dep.version, VersionConstraint.any);
-    expect(dep.hosted!.name, 'hosted_name');
-    expect(dep.hosted!.url, isNull);
+    expect(dep.hosted!.name, isNull);
+    expect(dep.hosted!.url, Uri.parse('hosted_url'));
     expect(dep.toString(), 'HostedDependency: any');
   });
 

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -120,6 +120,17 @@ line 4, column 10: Unsupported value for "dep". Could not parse version "not a v
     expect(dep.toString(), 'HostedDependency: ^1.0.0');
   });
 
+  test('map /w hosted as a map without name', () {
+    final dep = _dependency<HostedDependency>({
+      'version': '^1.0.0',
+      'hosted': {'url': 'https://hosted_url'}
+    }, skipTryPub: true); // todo: Unskip once pub supports this syntax
+    expect(dep.version.toString(), '^1.0.0');
+    expect(dep.hosted!.name, isNull);
+    expect(dep.hosted!.url.toString(), 'https://hosted_url');
+    expect(dep.toString(), 'HostedDependency: ^1.0.0');
+  });
+
   test('map w/ bad version value', () {
     _expectThrows(
       {
@@ -154,6 +165,7 @@ line 10, column 4: Unrecognized keys: [not_supported]; supported keys: [sdk, git
   test('map w/ version and hosted as String', () {
     final dep = _dependency<HostedDependency>(
       {'version': '^1.0.0', 'hosted': 'hosted_url'},
+      skipTryPub: true,
     );
     expect(dep.version.toString(), '^1.0.0');
     expect(dep.hosted!.name, isNull);

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -165,7 +165,7 @@ line 10, column 4: Unrecognized keys: [not_supported]; supported keys: [sdk, git
   test('map w/ version and hosted as String', () {
     final dep = _dependency<HostedDependency>(
       {'version': '^1.0.0', 'hosted': 'hosted_url'},
-      skipTryPub: true,
+      skipTryPub: true, // todo: Unskip once put supports this
     );
     expect(dep.version.toString(), '^1.0.0');
     expect(dep.hosted!.name, isNull);

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -121,12 +121,16 @@ line 4, column 10: Unsupported value for "dep". Could not parse version "not a v
   });
 
   test('map /w hosted as a map without name', () {
-    final dep = _dependency<HostedDependency>({
-      'version': '^1.0.0',
-      'hosted': {'url': 'https://hosted_url'}
-    }, skipTryPub: true); // todo: Unskip once pub supports this syntax
+    final dep = _dependency<HostedDependency>(
+      {
+        'version': '^1.0.0',
+        'hosted': {'url': 'https://hosted_url'}
+      },
+      skipTryPub: true, // todo: Unskip once pub supports this syntax
+    );
     expect(dep.version.toString(), '^1.0.0');
-    expect(dep.hosted!.name, isNull);
+    expect(dep.hosted!.declaredName, isNull);
+    expect(dep.hosted!.name, 'dep');
     expect(dep.hosted!.url.toString(), 'https://hosted_url');
     expect(dep.toString(), 'HostedDependency: ^1.0.0');
   });
@@ -168,7 +172,8 @@ line 10, column 4: Unrecognized keys: [not_supported]; supported keys: [sdk, git
       skipTryPub: true, // todo: Unskip once put supports this
     );
     expect(dep.version.toString(), '^1.0.0');
-    expect(dep.hosted!.name, isNull);
+    expect(dep.hosted!.declaredName, isNull);
+    expect(dep.hosted!.name, 'dep');
     expect(dep.hosted!.url, Uri.parse('hosted_url'));
     expect(dep.toString(), 'HostedDependency: ^1.0.0');
   });
@@ -176,7 +181,8 @@ line 10, column 4: Unrecognized keys: [not_supported]; supported keys: [sdk, git
   test('map w/ hosted as String', () {
     final dep = _dependency<HostedDependency>({'hosted': 'hosted_url'});
     expect(dep.version, VersionConstraint.any);
-    expect(dep.hosted!.name, isNull);
+    expect(dep.hosted!.declaredName, isNull);
+    expect(dep.hosted!.name, 'dep');
     expect(dep.hosted!.url, Uri.parse('hosted_url'));
     expect(dep.toString(), 'HostedDependency: any');
   });


### PR DESCRIPTION
Match the behavior of `hosted` from a future pub version as described in https://github.com/dart-lang/pub/issues/1806#issuecomment-923159714.

It looks like this package already supported a shorter form of hosted packages, but did not interpret them like pub will. Instead, it considers `hosted: foo` to be equivalent too `hosted: {name: foo}`.
This is also how pub treats those packages today, but I would consider this a bug in pub: It's not documented anywhere, untested and only happened due to a previously hacky implementation of description parsing in pub. It does not look intentional to me. If it is intentional, there are implications for the new syntax in pub because it's a breaking change then.

As `HostedDetails` is exported and `name` is now nullable, this is a breaking change in `pubspec_parse`. Since it looks like half of Dart's ecosystem depends on this package, do you see a way to avoid a breaking change? Maybe make `HostedDetails.name` default to the name of the dependency if none is given in the `hosted` map?

cc @jonasfj 