### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "autosubmit"


### PR DESCRIPTION
- have dependabot PRs be created with an `autosubmit` label