### PR TITLE
Pubspec overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.2.4-wip
+## 1.2.4
 
-- Require Dart 3.0
+- Require Dart `3.0`.
+- Add `pubspec_overrides` support.
 
 ## 1.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.2.4
 
 - Require Dart `3.0`.
-- Add `pubspec_overrides` support.
+- Add `pubspec_overrides` support via new `PubspecOverrides` class.
 
 ## 1.2.3
 

--- a/build.yaml
+++ b/build.yaml
@@ -6,6 +6,7 @@ targets:
       json_serializable:
         generate_for:
           - lib/src/pubspec.dart
+          - lib/src/pubspec_overrides.dart
           - lib/src/dependency.dart
         options:
           any_map: true

--- a/lib/pubspec_parse.dart
+++ b/lib/pubspec_parse.dart
@@ -11,4 +11,5 @@ export 'src/dependency.dart'
         PathDependency,
         SdkDependency;
 export 'src/pubspec.dart' show Pubspec;
+export 'src/pubspec_overrides.dart' show PubspecOverrides;
 export 'src/screenshot.dart' show Screenshot;

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -111,6 +111,18 @@ class SdkDependency extends Dependency {
 
   @override
   String get _info => sdk;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SdkDependency &&
+        other.sdk == sdk &&
+        other.version == version;
+  }
+
+  @override
+  int get hashCode => sdk.hashCode ^ version.hashCode;
 }
 
 @JsonSerializable()
@@ -136,6 +148,19 @@ class GitDependency extends Dependency {
 
   @override
   String get _info => 'url@$url';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is GitDependency &&
+        other.url == url &&
+        other.ref == ref &&
+        other.path == path;
+  }
+
+  @override
+  int get hashCode => url.hashCode ^ ref.hashCode ^ path.hashCode;
 }
 
 Uri? parseGitUriOrNull(String? value) =>
@@ -188,6 +213,16 @@ class PathDependency extends Dependency {
 
   @override
   String get _info => 'path@$path';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PathDependency && other.path == path;
+  }
+
+  @override
+  int get hashCode => path.hashCode;
 }
 
 @JsonSerializable(disallowUnrecognizedKeys: true)

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -204,6 +204,18 @@ class HostedDependency extends Dependency {
 
   @override
   String get _info => version.toString();
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is HostedDependency &&
+        other.version == version &&
+        other.hosted == hosted;
+  }
+
+  @override
+  int get hashCode => version.hashCode ^ hosted.hashCode;
 }
 
 @JsonSerializable(disallowUnrecognizedKeys: true)

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -111,18 +111,6 @@ class SdkDependency extends Dependency {
 
   @override
   String get _info => sdk;
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SdkDependency &&
-        other.sdk == sdk &&
-        other.version == version;
-  }
-
-  @override
-  int get hashCode => sdk.hashCode ^ version.hashCode;
 }
 
 @JsonSerializable()
@@ -148,19 +136,6 @@ class GitDependency extends Dependency {
 
   @override
   String get _info => 'url@$url';
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is GitDependency &&
-        other.url == url &&
-        other.ref == ref &&
-        other.path == path;
-  }
-
-  @override
-  int get hashCode => url.hashCode ^ ref.hashCode ^ path.hashCode;
 }
 
 Uri? parseGitUriOrNull(String? value) =>
@@ -213,16 +188,6 @@ class PathDependency extends Dependency {
 
   @override
   String get _info => 'path@$path';
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is PathDependency && other.path == path;
-  }
-
-  @override
-  int get hashCode => path.hashCode;
 }
 
 @JsonSerializable(disallowUnrecognizedKeys: true)
@@ -239,18 +204,6 @@ class HostedDependency extends Dependency {
 
   @override
   String get _info => version.toString();
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is HostedDependency &&
-        other.version == version &&
-        other.hosted == hosted;
-  }
-
-  @override
-  int get hashCode => version.hashCode ^ hosted.hashCode;
 }
 
 @JsonSerializable(disallowUnrecognizedKeys: true)

--- a/lib/src/pubspec_overrides.dart
+++ b/lib/src/pubspec_overrides.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:checked_yaml/checked_yaml.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'dependency.dart';
+
+part 'pubspec_overrides.g.dart';
+
+@JsonSerializable()
+class PubspecOverrides {
+  @JsonKey(fromJson: parseDeps)
+  final Map<String, Dependency> dependencyOverrides;
+
+  PubspecOverrides({Map<String, Dependency>? dependencyOverrides})
+      : dependencyOverrides = dependencyOverrides ?? const {};
+
+  factory PubspecOverrides.fromJson(Map json, {bool lenient = false}) {
+    if (lenient) {
+      while (json.isNotEmpty) {
+        // Attempting to remove top-level properties that cause parsing errors.
+        try {
+          return _$PubspecOverridesFromJson(json);
+        } on CheckedFromJsonException catch (e) {
+          if (e.map == json && json.containsKey(e.key)) {
+            json = Map.from(json)..remove(e.key);
+            continue;
+          }
+          rethrow;
+        }
+      }
+    }
+
+    return _$PubspecOverridesFromJson(json);
+  }
+
+  /// Parses source [yaml] into [PubspecOverrides].
+  ///
+  /// When [lenient] is set, top-level property-parsing or type cast errors are
+  /// ignored and `null` values are returned.
+  factory PubspecOverrides.parse(
+    String yaml, {
+    Uri? sourceUrl,
+    bool lenient = false,
+  }) =>
+      checkedYamlDecode(
+        yaml,
+        (map) => PubspecOverrides.fromJson(map!, lenient: lenient),
+        sourceUrl: sourceUrl,
+      );
+}

--- a/lib/src/pubspec_overrides.g.dart
+++ b/lib/src/pubspec_overrides.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, lines_longer_than_80_chars, require_trailing_commas, unnecessary_cast
+
+part of 'pubspec_overrides.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PubspecOverrides _$PubspecOverridesFromJson(Map json) => $checkedCreate(
+      'PubspecOverrides',
+      json,
+      ($checkedConvert) {
+        final val = PubspecOverrides(
+          dependencyOverrides: $checkedConvert(
+              'dependency_overrides', (v) => parseDeps(v as Map?)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'dependencyOverrides': 'dependency_overrides'},
+    );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_parse
-version: 1.2.4-wip
+version: 1.2.4
 description: >-
   Simple package for parsing pubspec.yaml files with a type-safe API and rich
   error reporting.

--- a/test/pubspec_overrides_test.dart
+++ b/test/pubspec_overrides_test.dart
@@ -14,7 +14,8 @@ dependency_overrides:
     expect(pubspecOverrides.dependencyOverrides.length, 1);
     final dependency = pubspecOverrides.dependencyOverrides.entries.first;
     expect(dependency.key, 'transmogrify');
-    expect(dependency.value, HostedDependency(version: Version(3, 2, 1)));
+    expect(dependency.value, isA<HostedDependency>());
+    expect((dependency.value as HostedDependency).version, Version(3, 2, 1));
   });
 
   test('Parsing pubspec_overrides.yaml in lenient mode', () {

--- a/test/pubspec_overrides_test.dart
+++ b/test/pubspec_overrides_test.dart
@@ -1,0 +1,34 @@
+import 'package:checked_yaml/checked_yaml.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/src/dependency.dart';
+import 'package:pubspec_parse/src/pubspec_overrides.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Parsing pubspec_overrides.yaml', () {
+    const yaml = '''
+dependency_overrides:
+  transmogrify: '3.2.1'
+''';
+    final pubspecOverrides = PubspecOverrides.parse(yaml);
+    expect(pubspecOverrides.dependencyOverrides.length, 1);
+    final dependency = pubspecOverrides.dependencyOverrides.entries.first;
+    expect(dependency.key, 'transmogrify');
+    expect(dependency.value, HostedDependency(version: Version(3, 2, 1)));
+  });
+
+  test('Parsing pubspec_overrides.yaml in lenient mode', () {
+    const yaml = '''
+dependency_overrides: true
+''';
+    expect(
+      () => PubspecOverrides.parse(yaml),
+      throwsA(isA<ParsedYamlException>()),
+    );
+
+    expect(
+      PubspecOverrides.parse(yaml, lenient: true).dependencyOverrides.length,
+      0,
+    );
+  });
+}

--- a/test/pubspec_overrides_test.dart
+++ b/test/pubspec_overrides_test.dart
@@ -9,13 +9,26 @@ void main() {
     const yaml = '''
 dependency_overrides:
   transmogrify: '3.2.1'
+  some_other_package:
+    git:
+      url: git@github.com:org/some_other_package
+      ref: some-branch
 ''';
     final pubspecOverrides = PubspecOverrides.parse(yaml);
-    expect(pubspecOverrides.dependencyOverrides.length, 1);
-    final dependency = pubspecOverrides.dependencyOverrides.entries.first;
-    expect(dependency.key, 'transmogrify');
-    expect(dependency.value, isA<HostedDependency>());
-    expect((dependency.value as HostedDependency).version, Version(3, 2, 1));
+    expect(pubspecOverrides.dependencyOverrides.length, 2);
+    final dependency1 = pubspecOverrides.dependencyOverrides.entries.first;
+    expect(dependency1.key, 'transmogrify');
+    expect(dependency1.value, isA<HostedDependency>());
+    expect((dependency1.value as HostedDependency).version, Version(3, 2, 1));
+
+    final dependency2 = pubspecOverrides.dependencyOverrides.entries.last;
+    expect(dependency2.key, 'some_other_package');
+    expect(dependency2.value, isA<GitDependency>());
+    expect(
+      (dependency2.value as GitDependency).url.toString(),
+      'ssh://git@github.com/org/some_other_package',
+    );
+    expect((dependency2.value as GitDependency).ref, 'some-branch');
   });
 
   test('Parsing pubspec_overrides.yaml in lenient mode', () {


### PR DESCRIPTION
Add support for `pubspec_overrides.yaml`, introduced [here](https://github.com/dart-lang/pub/pull/3215). 

Implementation detail: I thought it would be cleaner to create a new class instead of making this a special case of `PubSpec` parsing.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
