### PR TITLE
fix: Pubspec.environment can never be null

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -74,7 +74,7 @@ class Pubspec {
   final String? documentation;
 
   @JsonKey(fromJson: _environmentMap)
-  final Map<String, VersionConstraint?>? environment;
+  final Map<String, VersionConstraint?> environment;
 
   @JsonKey(fromJson: parseDeps)
   final Map<String, Dependency> dependencies;


### PR DESCRIPTION
Since `Pubspec.environment` defaults to an empty map in the initializer list it can never be null.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
